### PR TITLE
Firefox compatibility: change offsetLeft to layerX

### DIFF
--- a/js/imgslider.js
+++ b/js/imgslider.js
@@ -36,9 +36,9 @@
 		$(e.currentTarget).children('.instruction').hide();
 		var width;
 		if(e.type.startsWith('touch')){
-			width = e.originalEvent.touches[0].clientX - e.currentTarget.offsetLeft;
+			width = e.originalEvent.touches[0].clientX - e.originalEvent.layerX;
 		} else {
-			width = e.offsetX === undefined ? e.pageX - e.currentTarget.offsetLeft : e.offsetX;
+			width = e.offsetX === undefined ? e.pageX - e.originalEvent.layerX : e.offsetX;
 		}
 		if (width<=$(this).width()){
 			$(this).find('.left.image').css('width', width + 'px');


### PR DESCRIPTION
The slider didn't function correctly in some use cases in Firefox release 38.0, both in OS X and Windows 10.

Substituting e.currentTarget.offsetLeft with e.originalEvent.layerX ensures compatibility with this and other older versions of Firefox.
