### PR TITLE
Limit search for .instruction to the current context.

### DIFF
--- a/js/imgslider.js
+++ b/js/imgslider.js
@@ -13,7 +13,7 @@
 		if (settings.showInstruction) {
 			// Check if instruction div exists before adding
 			var $instrDiv = null;
-			$instrDiv = $('div.instruction');
+			$instrDiv = $('div.instruction', $this);
 
 			if ($instrDiv.length === 0) {
 				$instrDiv = $('<div></div>')


### PR DESCRIPTION
If there are multiple image sliders on a page only the first would have instruction text. With this change they all get instruction text. Also, if any other div with the class "instruction" existed instruction text wouldn't be added to any slider.